### PR TITLE
Fix comparison of fixnum to symbol crash

### DIFF
--- a/lib/active_record/session_store/extension/logger_silencer.rb
+++ b/lib/active_record/session_store/extension/logger_silencer.rb
@@ -32,7 +32,7 @@ module ActiveRecord
         end
 
         def add_with_threadsafety(severity, message = nil, progname = nil, &block)
-          if (defined?(@logdev) && @logdev.nil?) || (severity || UNKNOWN) < level
+          if (defined?(@logdev) && @logdev.nil?) || (severity || UNKNOWN) < (level.is_a?(Integer) ? level : Logger.const_get(level.to_s.upcase))
             true
           else
             add_without_threadsafety(severity, message, progname, &block)


### PR DESCRIPTION
  Log level in logger_silencer is for some reason `:warn` instead of an Integer.
  Might be a config issue somewhere. Just monkey patching this for now,
  as this gem will ultimately be removed once we're fully on Rails4.